### PR TITLE
Issue: GetActiveMessageTemplate failing to return active template

### DIFF
--- a/src/Libraries/Nop.Services/Messages/MessageTemplateService.cs
+++ b/src/Libraries/Nop.Services/Messages/MessageTemplateService.cs
@@ -170,7 +170,7 @@ namespace Nop.Services.Messages
             {
                 var query = _messageTemplateRepository.Table;
                 query = query.Where(t => t.Name == messageTemplateName);
-                query = query.OrderBy(t => t.Id);
+                query = query.OrderByDescending(t => t.IsActive).ThenByDescending(t => t.Id);
                 var templates = query.ToList();
 
                 //store mapping


### PR DESCRIPTION
We need to return the FirstOrDefault template in this order: 
1. Active First
2. The last one active created First